### PR TITLE
Upgrade alif-toolkit to avoid warning installing

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@turf/bbox-clip": "^6.0.0",
     "abortcontroller-polyfill": "^1.4.0",
     "aes-js": "^3.1.2",
-    "alif-toolkit": "^1.2.6",
+    "alif-toolkit": "^1.2.9",
     "browser-polyfills": "~1.5.0",
     "diacritics": "1.3.0",
     "fast-deep-equal": "~3.1.1",


### PR DESCRIPTION
`alif-toolkit@1.2.6` has request as dependency and this warning was raised running `npm install`:
```
alif-toolkit > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
```
After this commit, `alif-toolkit@1.2.9` hasn't request as dependency.